### PR TITLE
Replace Serializable with "constructor objects".

### DIFF
--- a/constructor.py
+++ b/constructor.py
@@ -1,0 +1,348 @@
+#!/usr/bin/env python3
+import types
+
+def constructed_by(con_type, copy_values=False):
+    '''
+    Attach a constructor type to the provided type.
+    This will allow calling the constructor type to construct instances of the
+    provided type, by copying fields from the constructor type.
+    This function doesn't impose any constraints on the two types, but generally
+    the constructor type should be picklable.
+    If the provided type might mutate the fields of provided by the
+    constructor, then copy_values should be 'deep' or 'shallow', as
+    appropriate.
+    Otherwise, (or if the constructor will be only be used once) copy_values can be
+    False or None.
+    '''
+    # Get the requested copy function.
+    copy_fn = lambda x: x
+    if copy_values:
+        import copy
+        if copy_values == 'deep':
+            copy_fn = copy.deepcopy
+        elif copy_values == 'shallow':
+            copy_fn = copy.copy
+        else:
+            raise TypeError(f'Invalid copy_values {copy_values}')
+
+    def constructed_by_decorator(constructed_type):
+        # Check that we haven't already attached this constructor.
+        if hasattr(con_type, '_constructed_type'):
+            raise TypeError(f'{con_type.__name__} cannot construct '
+            f'{constructed_type.__name__}, since it is already a constructor '
+            f'for {con_type._constructed_type.__name__}.')
+
+        # Check that the constructor type doesn't define __call__.
+        # Looking up __call__ will first attempt to get the class's field. If
+        # the class defines __call__, this will return a function type, since
+        # we're looking up through the class (and not an instance).
+        # If the class doesn't define __call__, looking up __call__ will look up
+        # the __call__ method defined on the `type` type itself.
+        class_has_call = isinstance(con_type.__call__, types.FunctionType)
+        if class_has_call and con_type.__call__ is not Constructor.__call__:
+            raise TypeError(f'{con_type.__name__} cannot be a constructor,'
+                            ' since it already defines __call__.')
+
+
+        con_type._constructed_type = constructed_type
+        # This is all of the real magic for `constructed_by`.
+        if (hasattr(con_type, '__slots__') or
+            hasattr(constructed_type, '__slots__')):
+            # Handle types with slots (this is slower).
+            import inspect
+            def instantiate(constructor):
+                instance = constructed_type.__new__(constructed_type)
+                for slot, value in inspect.getmembers(constructor):
+                    if not slot.endswith('__'):
+                        setattr(instance, slot, copy_fn(value))
+                instance.__init__()
+                return instance
+        else:
+            # Handle types without slots (this is faster).
+            if copy_values:
+                def instantiate(constructor):
+                    instance = constructed_type.__new__(constructed_type)
+                    fields = constructor.__dict__.items()
+                    instance.__dict__ = dict((k, copy_fn(v))
+                                             for k, v in fields)
+                    instance.__init__()
+                    return instance
+            else:
+                # This is the real fast path.
+                def instantiate(constructor):
+                    instance = constructed_type.__new__(constructed_type)
+                    instance.__dict__ = constructor.__dict__.copy()
+                    instance.__init__()
+                    return instance
+
+        # Finish attaching to the constructor type.
+        con_type.__call__ = instantiate
+        return constructed_type
+    return constructed_by_decorator
+
+
+class Constructor:
+
+    def __call__(self):
+        # This should only happen if constructed_by wasn't used to attach the
+        # specific Constructor type to a class.
+        raise TypeError(f"{type(self).__name__} doesn't construct any type.")
+
+# Simple simulation of deploying a Constructor.
+
+def test_deploy(constructor):
+    import pickle
+    print()
+    print('constructor', constructor)
+    s = pickle.dumps(constructor)
+    # print('pickled constructor', s)
+    loaded_constructor = pickle.loads(s)
+    # print('loaded constructor', s)
+    instance = loaded_constructor()
+    print('instance', instance)
+    print('second instance', loaded_constructor())
+    print()
+
+
+## Example without using Constructor:
+
+class MyEnv:
+
+    def __init__(self, name):
+        self._name = name
+
+
+import functools # pylint: disable=C0413
+
+test_deploy(functools.partial(MyEnv, 'MyEnv'))
+
+
+## Example with recommended practices.
+
+class ExampleEnvCon(Constructor):
+
+    def __init__(self, width, height=None):
+        if height is None:
+            height = width
+        self.width = width
+        self.height = height
+
+# If the decorator is forgotten, the following error occurs:
+#      TypeError: ExampleEnvCon doesn't construct any type
+@constructed_by(ExampleEnvCon)
+class ExampleEnv(ExampleEnvCon):
+    # To get better tab completion / pylint output, inherit from
+    # ExampleEnvCon, even though we don't need to.
+
+    def __init__(self):
+        # If we inherit, we still don't need to call the Constructor __init__(), so
+        # tell pylint.
+        # pylint: disable=W0231
+        print(f"creating ExampleEnv with {self.width}, {self.height}")
+        self._world = {}
+
+test_deploy(ExampleEnvCon(width=8))
+
+
+## Example with minimal practices.
+
+class MinimalCon:
+    def __init__(self, width, height=None):
+        if height is None:
+            height = width
+        self.width = width
+        self.height = height
+
+# If the decorator is forgotten, the following error occurs:
+#   TypeError: 'ExampleEnvCon' object is not callable
+@constructed_by(MinimalCon)
+class MinimalEnv:
+    # If we don't inherit, nothing breaks, but pylint and friends can no longer
+    # determine our fields.
+    # We probably want the following:
+    # pylint: disable=no-member
+
+    def __init__(self):
+        print(f"creating MinimalEnv with {self.width}, {self.height}")
+        self._world = {}
+
+test_deploy(MinimalCon(width=8))
+
+
+## Example with showing results of attaching constructor to two types.
+
+class RepeatedCon:
+    def __init__(self, width, height=None):
+        if height is None:
+            height = width
+        self.width = width
+        self.height = height
+
+@constructed_by(RepeatedCon)
+class FirstEnv:
+    # pylint: disable=no-member
+
+    def __init__(self):
+        print(f"creating FirstEnv with {self.width}, {self.height}")
+        self._world = {}
+
+try:
+    @constructed_by(RepeatedCon)
+    class SecondEnv(RepeatedCon):
+        pass
+except TypeError as e:
+    print()
+    print('Error message resulting from repeated constructed_by call:')
+    print(e)
+    print()
+
+
+## Example where both objects have slots.
+
+class BothHaveSlotsCon(Constructor):
+
+    __slots__ = ('width', 'height')
+
+    def __init__(self, width, height=None):
+        if height is None:
+            height = width
+        self.width = width
+        self.height = height
+
+
+@constructed_by(BothHaveSlotsCon)
+class BothHaveSlotsEnv(BothHaveSlotsCon):
+    __slots__ = ('width', 'height', '_world')
+
+    def __init__(self):
+        # pylint: disable=W0231
+        print(f"creating BothHaveSlotsEnv with {self.width}, {self.height}")
+        self._world = {}
+
+test_deploy(BothHaveSlotsCon(width=8))
+
+
+## Example where only the constructor object has slots.
+
+class OnlyConSlotsCon(Constructor):
+    __slots__ = ('width', 'height')
+
+    def __init__(self, width, height=None):
+        if height is None:
+            height = width
+        self.width = width
+        self.height = height
+
+
+@constructed_by(OnlyConSlotsCon)
+class OnlyConSlotsEnv(OnlyConSlotsCon):
+
+    def __init__(self):
+        # pylint: disable=W0231
+        print(f"creating OnlyConSlotsEnv with {self.width}, {self.height}")
+        self._world = {}
+
+test_deploy(OnlyConSlotsCon(width=8))
+
+
+## Example where only the constructed object has slots.
+
+class OnlyEnvSlotsCon(Constructor):
+
+    def __init__(self, width, height=None):
+        if height is None:
+            height = width
+        self.width = width
+        self.height = height
+
+
+@constructed_by(OnlyEnvSlotsCon)
+class OnlyEnvSlotsEnv(BothHaveSlotsCon):
+    __slots__ = ('width', 'height', '_world')
+
+    def __init__(self):
+        # pylint: disable=W0231
+        print(f"creating OnlyEnvSlotsEnv with {self.width}, {self.height}")
+        self._world = {}
+
+test_deploy(OnlyEnvSlotsCon(width=8))
+
+
+## Example using `attr`
+
+try:
+    import attr
+    @attr.s(slots=True)
+    class WithAttrSlotsCon(Constructor):
+
+        width = attr.ib()
+        height = attr.ib()
+
+        @height.default
+        def height_default(self):
+            return self.width
+
+
+    # Note that inheriting from the WithAttrSlotsCon doesn't work, since
+    # `attr` invokes the constructor's `__init__`. However, it doesn't have
+    # any parameters, which causes the constructor's `__init__` to fail.
+    @attr.s
+    @constructed_by(WithAttrSlotsCon)
+    class WithAttrEnv:
+        # pylint: disable=no-member
+
+        world = attr.ib(factory=dict)
+
+        def __attrs_post_init__(self):
+            print(f"creating WithAttrEnv with {self.width}, {self.height}")
+
+    test_deploy(WithAttrSlotsCon(width=8))
+except ImportError:
+    print("Install attr to run attr example.")
+
+
+## Example with multiple instances without copying.
+
+class CopyCon:
+    def __init__(self, x):
+        self.x = x
+        self.world = ['from_constructor']
+
+@constructed_by(CopyCon, copy_values='shallow')
+class CopyEnv:
+    # If we don't inherit, nothing breaks, but pylint and friends can no longer
+    # determine our fields.
+    # We probably want the following:
+    # pylint: disable=no-member
+
+    def __init__(self):
+        self.world.append('item')
+        print(f"populating world CopyEnv: {self.world}")
+
+test_deploy(CopyCon(x='x'))
+
+
+## Example with a constructor that already defined __call__.
+
+class ErroneousCon:
+
+    def __init__(self, width, height=None):
+        if height is None:
+            height = width
+        self.width = width
+        self.height = height
+
+    def __call__(self):
+        print('oh no!')
+
+try:
+    @constructed_by(ErroneousCon)
+    class ErroneousEnv:
+        pass
+except TypeError as e:
+    print()
+    print('Error message resulting from constructor defining __call__:')
+    # ErroneousCon cannot be a constructor, since it already defines
+    # __call__.
+    print(e)
+    print()

--- a/constructor_objects.md
+++ b/constructor_objects.md
@@ -37,39 +37,40 @@ subprocess, etc.), you would do something like this (extracted from
 garage/envs/mujoco/gather/gather_env.py):
 
 ```python
-    from garage.core import Serializable
+from garage.core import Serializable
 
-    class GatherEnv(Serializable):
+class GatherEnv(Serializable):
 
-        def __init__(self, n_apples=8, n_bombs=8):
-            self.n_apples = n_apples
-            self.n_bombs = n_bombs
+    def __init__(self, n_apples=8, n_bombs=8):
+        self.n_apples = n_apples
+        self.n_bombs = n_bombs
 
-                # Always call Serializable constructor last
-            Serializable.quick_init(self, locals())
-
-    In experiment file (at least in principle):
-
-    env = GatherEnv(3, 2)
-
-    run_experiment(..., env=env)
-```
-
-I propose replacing it the following interface:
-
-```python
-
-  class GatherEnv:
-
-      def __init__(self, n_apples=8, n_bombs=8):
-          self.n_apples = n_apples
-          self.n_bombs = n_bombs
+            # Always call Serializable constructor last
+        Serializable.quick_init(self, locals())
 ```
 
 In experiment file (at least in principle):
 
 ```python
-  run_experiment(..., env_con=functools.partial(GatherEnv, 3, 2))
+env = GatherEnv(3, 2)
+
+run_experiment(..., env=env)
+```
+
+I propose replacing it the following interface:
+
+```python
+class GatherEnv:
+
+    def __init__(self, n_apples=8, n_bombs=8):
+        self.n_apples = n_apples
+        self.n_bombs = n_bombs
+```
+
+In experiment file (at least in principle):
+
+```python
+run_experiment(..., env_con=functools.partial(GatherEnv, 3, 2))
 ```
 
 For types with many parameters (e.g. most environments in practice),
@@ -78,24 +79,25 @@ handle that case, I’ve made a simple decorator to help split a class into a
 constructor type and the main type:
 
 ```python
-  class GatherEnvCon:
+class GatherEnvCon:
 
-      def __init__(self, n_apples=8, n_bombs=8):
-          self.n_apples = n_apples
-          self.n_bombs = n_bombs
+    def __init__(self, n_apples=8, n_bombs=8):
+        self.n_apples = n_apples
+        self.n_bombs = n_bombs
 
-  @constructed_by(GatherEnvCon)
-  class GatherEnv:
+@constructed_by(GatherEnvCon)
+class GatherEnv:
 
-      def __init__(self):
-          # constructor fields are already set
-          for apple in range(self.n_apples):
-              ...
+    def __init__(self):
+        # constructor fields are already set
+        for apple in range(self.n_apples):
+            ...
 ```
 
 In experiment file (at least in principle):
+
 ```python
-  run_experiment(..., env_con=GatherEnvCon(3, 2))
+run_experiment(..., env_con=GatherEnvCon(3, 2))
 ```
 
 A simple version of the source is in `constructor_simple.py`. I more

--- a/constructor_objects.md
+++ b/constructor_objects.md
@@ -1,0 +1,102 @@
+Constructor Objects
+===================
+
+## Background
+
+Currently in Garage, we have two general methods of “serializing” types.
+
+The for stateful objects (basically just neural networks), we have
+`Parameterized`, which is used to essentially store the network's weights in a
+picklable dictionary. The logic for doing that is not very magic, and not
+necessary for more recent frameworks, since the frameworks provide equivalent
+functions (e.g.  `torch.nn.Module.named_parameters()`,
+`mxnet.gluon.Block.collect_params()`). We can simply define a common interface
+for getting / setting a picklable version of a model, which is shared by all of
+these frameworks. However, `Parameterized` also inherits
+from the other serialization type.
+
+The other (more magic) serialization type we have is `Serializable`, which is
+used for stateless types. It functions by capturing the parameters to
+`__init__`, and serializing those instead of the object itself. This is not an
+obvious interface, and generally doesn’t do exactly what we want. Usually we
+want to describe how to construct an object, then transmit that. But
+`Serializable` requires additional hacks to achieve that. Furthermore,
+`Serializable` has basically permeated the code base, being inherited from in a
+bunch of places it’s not needed.
+
+
+## Proposal
+
+I propose replacing Serializable with the use of "constructor objects."
+Constructor objects are just pickleable objects that can be invoked to
+construct instances of their corresponding type.
+
+That’s too abstract to easily understand, so here’s an example.
+Currently, if you have an environment that can’t be pickled (since it opens a
+subprocess, etc.), you would do something like this (extracted from
+garage/envs/mujoco/gather/gather_env.py):
+
+```python
+    from garage.core import Serializable
+
+    class GatherEnv(Serializable):
+
+        def __init__(self, n_apples=8, n_bombs=8):
+            self.n_apples = n_apples
+            self.n_bombs = n_bombs
+
+                # Always call Serializable constructor last
+            Serializable.quick_init(self, locals())
+
+    In experiment file (at least in principle):
+
+    env = GatherEnv(3, 2)
+
+    run_experiment(..., env=env)
+```
+
+I propose replacing it the following interface:
+
+```python
+
+  class GatherEnv:
+
+      def __init__(self, n_apples=8, n_bombs=8):
+          self.n_apples = n_apples
+          self.n_bombs = n_bombs
+```
+
+In experiment file (at least in principle):
+
+```python
+  run_experiment(..., env_con=functools.partial(GatherEnv, 3, 2))
+```
+
+For types with many parameters (e.g. most environments in practice),
+`functools.partial` has the weakness that it doesn’t check any parameters.  To
+handle that case, I’ve made a simple decorator to help split a class into a
+constructor type and the main type:
+
+```python
+  class GatherEnvCon:
+
+      def __init__(self, n_apples=8, n_bombs=8):
+          self.n_apples = n_apples
+          self.n_bombs = n_bombs
+
+  @constructed_by(GatherEnvCon)
+  class GatherEnv:
+
+      def __init__(self):
+          # constructor fields are already set
+          for apple in range(self.n_apples):
+              ...
+```
+
+In experiment file (at least in principle):
+```python
+  run_experiment(..., env_con=GatherEnvCon(3, 2))
+```
+
+A simple version of the source is in `constructor_simple.py`. I more
+sophisticated version which handles `__slots__` is in `constructor.py`.

--- a/constructor_objects.md
+++ b/constructor_objects.md
@@ -45,7 +45,8 @@ class GatherEnv(Serializable):
         self.n_apples = n_apples
         self.n_bombs = n_bombs
 
-            # Always call Serializable constructor last
+        # Serializable constructor is often called last, but should usually be
+        # called first.
         Serializable.quick_init(self, locals())
 ```
 
@@ -88,7 +89,7 @@ class GatherEnvCon:
 @constructed_by(GatherEnvCon)
 class GatherEnv:
 
-    def __init__(self):
+    def construct(self):
         # constructor fields are already set
         for apple in range(self.n_apples):
             ...

--- a/constructor_simple.py
+++ b/constructor_simple.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+import copy
+import types
+
+def constructed_by(con_type):
+    '''
+    Attach a constructor type to the provided type.
+    This will allow calling instances of the constructor type to construct
+    instances of the provided type, by copying fields from the constructor
+    object.
+    This function doesn't impose any constraints on the two types, but generally
+    the constructor type should be picklable.
+    '''
+    def constructed_by_decorator(constructed_type):
+        # Check that we haven't already attached this constructor.
+        if hasattr(con_type, '_constructed_type'):
+            raise TypeError(f'{con_type.__name__} cannot construct '
+            f'{constructed_type.__name__}, since it is already a constructor '
+            f'for {con_type._constructed_type.__name__}.')
+
+        # Check that the constructor type doesn't define __call__.
+        # Looking up __call__ will first attempt to get the class's field. If
+        # the class defines __call__, this will return a function type, since
+        # we're looking up through the class (and not an instance).
+        # If the class doesn't define __call__, looking up __call__ will look up
+        # the __call__ method defined on the `type` type itself.
+        class_has_call = isinstance(con_type.__call__, types.FunctionType)
+        if class_has_call and con_type.__call__ is not Constructor.__call__:
+            raise TypeError(f'{con_type.__name__} cannot be a constructor,'
+                            ' since it already defines __call__.')
+
+        con_type._constructed_type = constructed_type
+        def instantiate(constructor):
+            instance = constructed_type.__new__(constructed_type)
+            instance.__dict__ = dict((k, copy.deepcopy(v))
+                                     for k, v in constructor.__dict__.items())
+            instance.__init__()
+            return instance
+
+        # Finish attaching to the constructor type.
+        con_type.__call__ = instantiate
+        return constructed_type
+    return constructed_by_decorator
+
+
+class Constructor:
+
+    def __call__(self):
+        # This should only happen if constructed_by wasn't used to attach the
+        # specific Constructor type to a class.
+        raise TypeError(f"{type(self).__name__} doesn't construct any type.")
+
+# Simple simulation of deploying a constructor.
+
+def test_deploy(constructor):
+    import pickle
+    print()
+    print('constructor', constructor)
+    s = pickle.dumps(constructor)
+    # print('pickled constructor', s)
+    loaded_constructor = pickle.loads(s)
+    # print('loaded constructor', s)
+    instance = loaded_constructor()
+    print('instance', instance)
+    print()
+
+
+## Example without using constructor:
+
+class MyEnv:
+
+    def __init__(self, name):
+        self._name = name
+
+# We can't pickle a lambda, so we use `functools.partial` for this example.
+import functools # pylint: disable=C0413
+
+test_deploy(functools.partial(MyEnv, 'MyEnv'))
+
+
+## Example with recommended practices.
+
+class ExampleEnvCon(Constructor):
+
+    def __init__(self, width, height=None):
+        if height is None:
+            height = width
+        self.width = width
+        self.height = height
+
+# If the decorator is forgotten, the following error occurs:
+#      TypeError: ExampleEnvCon doesn't construct any type
+@constructed_by(ExampleEnvCon)
+class ExampleEnv(ExampleEnvCon):
+    # To get better tab completion / pylint output, inherit from
+    # ExampleEnvCon, even though we don't need to.
+
+    def __init__(self):
+        # If we inherit, we still don't need to call the Constructor __init__(), so
+        # tell pylint.
+        # pylint: disable=W0231
+        print(f"creating ExampleEnv with {self.width}, {self.height}")
+        self._world = {}
+
+test_deploy(ExampleEnvCon(width=8))
+
+
+## Example with minimal practices.
+
+class MinimalCon:
+    def __init__(self, width, height=None):
+        if height is None:
+            height = width
+        self.width = width
+        self.height = height
+
+# If the decorator is forgotten, the following error occurs:
+#   TypeError: 'ExampleEnvCon' object is not callable
+@constructed_by(MinimalCon)
+class MinimalEnv:
+    # If we don't inherit, nothing breaks, but pylint and friends can no longer
+    # determine our fields.
+    # We probably want the following:
+    # pylint: disable=no-member
+
+    def __init__(self):
+        print(f"creating MinimalEnv with {self.width}, {self.height}")
+        self._world = {}
+
+test_deploy(MinimalCon(width=8))
+
+
+## Example with showing results of attaching constructor to two types.
+
+class RepeatedCon:
+    def __init__(self, width, height=None):
+        if height is None:
+            height = width
+        self.width = width
+        self.height = height
+
+@constructed_by(RepeatedCon)
+class FirstEnv:
+    # pylint: disable=no-member
+
+    def __init__(self):
+        print(f"creating FirstEnv with {self.width}, {self.height}")
+        self._world = {}
+
+try:
+    @constructed_by(RepeatedCon)
+    class SecondEnv(RepeatedCon):
+        pass
+except TypeError as e:
+    print()
+    print('Error message resulting from repeated constructed_by call:')
+    # RepeatedCon cannot construct SecondEnv, since it is already a
+    # constructor for FirstEnv.
+    print(e)
+    print()
+
+
+## Example with a constructor that already defined __call__.
+
+class ErroneousCon:
+
+    def __init__(self, width, height=None):
+        if height is None:
+            height = width
+        self.width = width
+        self.height = height
+
+    def __call__(self):
+        print('oh no!')
+
+try:
+    @constructed_by(ErroneousCon)
+    class ErroneousEnv:
+        pass
+except TypeError as e:
+    print()
+    print('Error message resulting from constructor defining __call__:')
+    # ErroneousCon cannot be a constructor, since it already defines
+    # __call__.
+    print(e)
+    print()


### PR DESCRIPTION
A rendered version of the proposal is [here](https://github.com/rlworkgroup/proposals/blob/constructor-objects/constructor_objects.md).
Essentially, the goal here is to replace the magic of `Serializable`, with a much more explicit, but not less verbose, mechanism for producing instances of non-picklable types.

I would like explicitly like feedback on the naming of things, the general approach, the API, and alternative proposals.